### PR TITLE
don't delete teams that were not manually created

### DIFF
--- a/src/scripts/sync_teams/sync_teams.py
+++ b/src/scripts/sync_teams/sync_teams.py
@@ -218,7 +218,7 @@ def main():
     update_assets(jit_token, assets, organization)
 
     if teams_to_delete:
-        logger.info(f"Deleting {len(teams_to_delete)} team(s): {teams_to_delete}")
+        logger.info(f"Checking which team(s) to delete from: {teams_to_delete}")
         delete_teams(jit_token, teams_to_delete)
     logger.info("Successfully completed teams sync.")
 

--- a/src/shared/clients/jit.py
+++ b/src/shared/clients/jit.py
@@ -98,7 +98,7 @@ def delete_teams(token, team_names):
                 break
 
         # We only delete teams that are manually created
-        if team_id and selected_team and selected_team['source'] == MANUAL_TEAM_SOURCE:
+        if team_id and selected_team and selected_team.source == MANUAL_TEAM_SOURCE:
             url = f"{get_jit_endpoint_base_url()}/teams/{team_id}"
             headers = {"Authorization": f"Bearer {token}"}
 

--- a/src/shared/clients/jit.py
+++ b/src/shared/clients/jit.py
@@ -98,17 +98,20 @@ def delete_teams(token, team_names):
                 break
 
         # We only delete teams that are manually created
-        if team_id and selected_team and selected_team.source == MANUAL_TEAM_SOURCE:
-            url = f"{get_jit_endpoint_base_url()}/teams/{team_id}"
-            headers = {"Authorization": f"Bearer {token}"}
+        if team_id:
+            if selected_team and selected_team.source == MANUAL_TEAM_SOURCE:
+                url = f"{get_jit_endpoint_base_url()}/teams/{team_id}"
+                headers = {"Authorization": f"Bearer {token}"}
 
-            response = requests.delete(url, headers=headers)
+                response = requests.delete(url, headers=headers)
 
-            if response.status_code == 204:
-                logger.info(f"Team '{team_name}' deleted successfully.")
+                if response.status_code == 204:
+                    logger.info(f"Team '{team_name}' deleted successfully.")
+                else:
+                    logger.error(
+                        f"Failed to delete team '{team_name}'. Status code: {response.status_code}, {response.text}")
             else:
-                logger.error(
-                    f"Failed to delete team '{team_name}'. Status code: {response.status_code}, {response.text}")
+                logger.info(f"Team '{team_name}' is not manually created. Skipping deletion.")
         else:
             logger.warning(f"Team '{team_name}' not found.")
 

--- a/src/shared/clients/jit.py
+++ b/src/shared/clients/jit.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import requests
 from loguru import logger
+from src.shared.consts import MANUAL_TEAM_SOURCE
 from src.shared.env_tools import get_jit_endpoint_base_url
 from src.shared.models import Asset, TeamAttributes
 
@@ -89,12 +90,15 @@ def delete_teams(token, team_names):
 
     for team_name in team_names:
         team_id = None
+        selected_team = None
         for team in existing_teams:
             if team.name == team_name:
                 team_id = team.id
+                selected_team = team
                 break
 
-        if team_id:
+        # We only delete teams that are manually created
+        if team_id and selected_team and selected_team['source'] == MANUAL_TEAM_SOURCE:
             url = f"{get_jit_endpoint_base_url()}/teams/{team_id}"
             headers = {"Authorization": f"Bearer {token}"}
 


### PR DESCRIPTION
sc-19672-create-a-tool-to-generate-teams-from-github

small fix: don't delete teams that weren't manually created